### PR TITLE
fix crystallabs/crysterm#32 (resize issue on macOS)

### DIFF
--- a/src/tput/coordinates.cr
+++ b/src/tput/coordinates.cr
@@ -6,11 +6,7 @@ class Tput
     # Gets terminal/screen size as number of columns and rows.
     def get_screen_size
       r, c = ENV["TPUT_SCREEN_SIZE"]?.try { |s| s.split('x', 2).map &.to_i } ||
-             Term::Screen.size_from_ioctl(STDIN) ||
-             Term::Screen.size_from_ioctl(STDOUT) ||
-             Term::Screen.size_from_ioctl(STDERR) ||
-             Term::Screen.size_from_env ||
-             Term::Screen.size_from_ansicon ||
+             Term::Screen.size ||
              {DEFAULT_SCREEN_SIZE.height, DEFAULT_SCREEN_SIZE.width}
       s = Size.new c, r
       Log.trace { my s }


### PR DESCRIPTION
This one fixes https://github.com/crystallabs/crysterm/issues/32 

Since **crystal-posix/ioctl.cr** hardcodes an incompatible address of TIOCGWINSZ,
https://github.com/crystal-posix/ioctl.cr/blob/master/src/asm-generic/ioctls.cr#L37

we should try to fall-back to the rest of the checks defined in `size`
https://github.com/crystal-term/screen/blob/master/src/term-screen.cr#L31

```crystal
check_size(size_from_tput) ||
check_size(size_from_readline) ||
check_size(size_from_stty) ||
check_size(size_from_env) ||
check_size(size_from_ansicon) ||
check_size(size_from_default) ||
```
